### PR TITLE
La linea editada contiene un espacio que hace que al ejecutar falle.

### DIFF
--- a/chapter04.rst
+++ b/chapter04.rst
@@ -310,7 +310,7 @@ plantilla de muestra del comienzo de este capítulo::
     >>> raw_template = """<p>Estimado: {{ nombre }},</p>
     ...
     ... <p>Gracias por el pedido que ordeno de {{ empresa }}. El pedido
-    ... se enviara el {{ ship_date|date: "j F Y"  }}.</p>
+    ... se enviara el {{ ship_date|date:"j F Y"  }}.</p>
     ...
     ... {% if garantía %}
     ... <p>La garantía será incluida en el paquete.</p>

--- a/chapter04.rst
+++ b/chapter04.rst
@@ -586,9 +586,9 @@ método:
 
 .. code-block:: python
 
-          def delete(self):
+          def borrar(self):
               # Borra una cuenta
-          delete.alters_data = True
+          borrar.alters_data = True
 
 .. admonition:: ¿Que es self?
 
@@ -601,7 +601,7 @@ método:
 El sistema de plantillas no debería ejecutar cualquier método marcado de
 esta forma. En otras palabras, si una plantilla incluye ``{{ cuenta.borrar}}``,
 y el método ``borrar()``, marcado como ``alters_data=True``, esta etiqueta no
-ejecutará el método ``delete()``. Ya que este fallará silenciosamente.
+ejecutará el método ``borrar()``. Ya que este fallará silenciosamente.
 
 ¿Cómo se manejan las variables inválidas?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
 t = Template(raw_template)
tira el siguiente error:

TemplateSyntaxError: Could not parse the remainder: ': "j F Y"' from 'ship_date|date: "j F Y"'

Revisando en el libro en ingles, no existe el espacio entre ":" y "j F Y". Al unir esto el error desaparece.
